### PR TITLE
Add bad runtime test combining shadowing and self initialization

### DIFF
--- a/bad-runtime/uninit_int_init_shadow.cc
+++ b/bad-runtime/uninit_int_init_shadow.cc
@@ -1,0 +1,7 @@
+int main() {
+  int x = 42;
+  {
+    int x = x;
+  }
+  return 0;
+}


### PR DESCRIPTION
The test should produce a runtime error, since the `x` on the rhs of the initialization of `x` refers to the variable that is initialized, not the shadowed variable initialized two lines above.

Essentially, this tests whether the interpreter handles initializations correctly. In the case without the shadowing, not adding an uninitialized variable to the environment would also produce a runtime error. In this test case, this does not happen.